### PR TITLE
Add RavenClient config to sugar config

### DIFF
--- a/Sentry.php
+++ b/Sentry.php
@@ -162,10 +162,10 @@ class Sentry
      * @return array
      */
     protected function getTagsContext() {
-        global $sugar_config;
+        global $suitecrm_version;
 
         $tags = array(
-            'suitecrm_version' => $sugar_config['suitecrm_version']
+            'suitecrm_version' => $suitecrm_version
         );
 
         return $tags;


### PR DESCRIPTION
It also adds suitecrm_version to the Sentry context.

This allows users to provide an array at `['sentry']['raven_client_config']` and it'll be passed to the Sentry Raven Client initializer.

This is mostly useful for users who want to [set custom settings for the client](https://docs.sentry.io/clients/php/config/#available-settings).

For example:

```php
$sugar_config['sentry']['raven_client_config'] = array(
  'release' => '1234abc',
  'environment' => 'development'
);
```